### PR TITLE
Fix uses of "list" where it's really an array

### DIFF
--- a/page/basics/loops/index.markdown
+++ b/page/basics/loops/index.markdown
@@ -5,11 +5,11 @@
 Traditional `for` loops exist but you almost never need them in Perl.
 `foreach` is usually simpler.
 
-Iterating over a list
+Iterating over an array
 
-    my @list = (1, 2, 3, 4);
+    my @array = (1, 2, 3, 4);
 
-    foreach my $i (@list) {
+    foreach my $i (@array) {
         print $i, "\n";
     }
 
@@ -34,7 +34,7 @@ Iterating over a hash
 
 This works with any kind of loop.
 
-    foreach my $i (@list) {
+    foreach my $i (@array) {
         print $i, "\n";
         last if $i > 3; # break out of the loop early
     }
@@ -43,7 +43,7 @@ This works with any kind of loop.
 
 This also works with any kind of loop.
 
-    foreach my $i (@list) {
+    foreach my $i (@array) {
         next if $i > 3; # don't print anything for $i > 3
         print $i, "\n";
     }

--- a/page/basics/references/index.markdown
+++ b/page/basics/references/index.markdown
@@ -10,28 +10,28 @@ A reference is like a pointer.  It's a scalar value containing the address of
 another value.  Perl will not automatically dereference a variable for you.
 References are scalars so they always start with a <code>$</code>.  
 
-#### List references
+#### Array references
 
-Also called list refs for short.
+Also called array refs for short.
 
-    my @list = (1, 2, 3, 4);             # list
-    my $listref1 = \@list;               # list reference
-    my $listref2 = ['a', 'b', 'c', 'd']; # list reference
+    my @array = (1, 2, 3, 4);             # array
+    my $arrayref1 = \@array;              # array reference
+    my $arrayref2 = ['a', 'b', 'c', 'd']; # array reference
 
-    # Access element 0 of the list 
-    print $list[0];       # prints 1
+    # Access element 0 of the array
+    print $array[0];       # prints 1
 
     # Dereference + access element 0
-    print $listref1->[0]; # prints 1
-    print $listref2->[0]; # prints 'a'
+    print $arrayref1->[0]; # prints 1
+    print $arrayref2->[0]; # prints 'a'
 
-    # A list reference inside a list reference
-    my $lists_in_lists = [a, b, c, ['roo', 'woo', 'loo']];
+    # A array reference inside a array reference
+    my $arrays_in_arrays = [a, b, c, ['roo', 'woo', 'loo']];
 
-    # How to dereference list references
-    my @list1 = @{ $lists_in_lists };      # (a, b, c ['roo', 'woo', 'loo'])
-    my @list2 = @$listref;                 # same but less typing
-    my @list3 = @{ $lists_in_lists->[3] }; # ('roo', 'woo', 'loo')
+    # How to dereference array references
+    my @array1 = @{ $arrays_in_arrays };      # (a, b, c ['roo', 'woo', 'loo'])
+    my @array2 = @$arrayref;                  # same but less typing
+    my @array3 = @{ $arrays_in_arrays->[3] }; # ('roo', 'woo', 'loo')
 
 #### Hash references
 
@@ -72,8 +72,8 @@ AKA code refs, anonymous subroutines, anonymous functions, closures, or callback
 
 Mastering this topic requires some memorization and a lot of practice.  Key things to remember:
 
-- <code>[ ... ]</code> creates a list reference
+- <code>[ ... ]</code> creates a array reference
 - <code>{ ... }</code> creates a hash reference
-- <code>@$var</code> or <code>@{ ... }</code> dereferences a list
+- <code>@$var</code> or <code>@{ ... }</code> dereferences a array
 - <code>%$var</code> or <code>%{ ... }</code> dereferences a hash
 

--- a/page/basics/variables/index.markdown
+++ b/page/basics/variables/index.markdown
@@ -8,8 +8,8 @@ variables always start with a <code>$</code>.  For example:
 
     my $foo = 'dinosaur';
 
-#### Lists
-A list is an ordered set of scalar values.  List variables always start with an
+#### Arrays
+A array is an ordered set of scalar values.  Array variables always start with an
 <code>@</code>.  For example:
 
     my @foo = (1, 2, 3, 'cowboy');


### PR DESCRIPTION
An array is a variable (or an anonymous array ref). A list is the thing in
parens that you can assign to an array variable. They're not quite the same,
and lists and arrays behave differently in a few cases.

```perl
use v5.26;
my @array = (2, 4, 6); # the thing with the parens is a list
my $x = @array;
my $y = (2, 4, 6);
say $x;
say $y;
```

This outputs `3` and `6`.