### PR TITLE
Add missing semicolons

### DIFF
--- a/page/debugging/stack-trace/index.markdown
+++ b/page/debugging/stack-trace/index.markdown
@@ -49,7 +49,7 @@ How to force a stack trace in just one place in your code with
     use strict;
     use warnings;
 
-    use Carp 'confess'
+    use Carp 'confess';
 
     sub function3 { confess 'die with a stack trace' }
     sub function2 { function3() }

--- a/page/oo/attributes/index.markdown
+++ b/page/oo/attributes/index.markdown
@@ -44,7 +44,7 @@ Best practices:
 Normal attributes are initialized during object construction.  Lazy attributes
 are not initialized until the attribute is used.
 
-    has tentacles => (is => 'ro', lazy => 1, builder => '_build_tentacles')
+    has tentacles => (is => 'ro', lazy => 1, builder => '_build_tentacles');
 
 Best practices:
 


### PR DESCRIPTION
Hi! Thanks for creating this great resource.

I was browsing it, and found out that in two places there was a semicolon missing. One (tentacles) is probably not as important, as it's just one line that is not meant to be run by itself, but the other (use Carp) causes a syntax error when copy/pasted.

I hope you find this PR useful. Happy holidays!