### PR TITLE
Correct instances of "its" vs. "it's".

### DIFF
--- a/page/about/index.markdown
+++ b/page/about/index.markdown
@@ -35,7 +35,7 @@ etc).
 I've tried to provide quick and simple explanations for the first 2 issues in
 this book.  But my theory is most issues are due to the lack of a good,
 concise, easily digestable, easy to navigate, online source of information and
-answers in a single location.  The information is out there but its not easy
+answers in a single location.  The information is out there but it's not easy
 for new people to find.  This is my attempt to solve that problem.
 
 #### Contributing

--- a/page/basics/flow/index.markdown
+++ b/page/basics/flow/index.markdown
@@ -3,13 +3,13 @@
 Comparing numbers:
 
     if ($eyeballs >= 2) {
-        print "its an alien\n";
+        print "it's an alien\n";
     }
     elsif ($eyeballs == 2) {
-        print "its human\n";
+        print "it's human\n";
     }
     else {
-        print "its a rock\n";
+        print "it's a rock\n";
     }
 
 Comparing strings requires different operaters:

--- a/page/basics/references/index.markdown
+++ b/page/basics/references/index.markdown
@@ -1,4 +1,4 @@
-You will need to understand references.  However its also <i>the most
+You will need to understand references.  However it's also <i>the most
 frustrating</i> and time consuming part of learning Perl for everyone.  If you
 can master this you will be able to read and write Perl code.  <i>Be sure to
 read the section "Key Things to Remember" at the bottom! </i>

--- a/page/basics/regexps/index.markdown
+++ b/page/basics/regexps/index.markdown
@@ -41,7 +41,7 @@ regexps apply to `s///` as well.
 
 #### Commenting regexps with the /x modifier
 
-Its useful to comment long complicated regular expressions for clarity.
+It's useful to comment long complicated regular expressions for clarity.
 For example, this:
 
     $code =~ s|/\*.*?\*/||gs;

--- a/page/books/index.markdown
+++ b/page/books/index.markdown
@@ -79,7 +79,7 @@ data:
       amazon: 'https://www.amazon.com/gp/product/1449303706/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=1449303706&linkCode=as2&tag=kablamo-20&linkId=6909fba99244deac34b8c2c22782e2df'
     - title: Working Effectively With Legacy Code
       published: 2005
-      description: Not a Perl book, but its a good book.  This book was published in 2005 but I'd argue its timeless.
+      description: Not a Perl book, but it's a good book.  This book was published in 2005 but I'd argue it's timeless.
       img: /images/legacy-code.jpg
       amazon: 'https://www.amazon.com/gp/product/0131177052/ref=as_li_tl?ie=UTF8&camp=1789&creative=9325&creativeASIN=0131177052&linkCode=as2&tag=kablamo-20&linkId=667d392b057a70629d98c65523ca91ba'
 

--- a/page/community/index.markdown
+++ b/page/community/index.markdown
@@ -5,7 +5,7 @@ title: Community
 
 #### IRC
 
-The Perl community loves IRC and its a great place to ask questions.
+The Perl community loves IRC and it's a great place to ask questions.
 
 [irc.perl.org](http://www.irc.perl.org/)
 

--- a/page/cpan/exceptions/index.markdown
+++ b/page/cpan/exceptions/index.markdown
@@ -60,12 +60,12 @@ try/catch syntax.
 
 However, Try::Tiny is an order of magnitude slower than either `eval` or
 Syntax::Keyword::Try.  It depends on your application if this is a problem or
-not.  For many applications its not important. 
+not.  For many applications it's not important. 
 
 Also if you are a visitor from another language, Try::Tiny has syntax quirks
 which make it not quite the try/catch you are used to.
 
-Be sure to check out Syntax::Keyword::Try as its probably a better solution for
+Be sure to check out Syntax::Keyword::Try as it's probably a better solution for
 most people.
 
 
@@ -109,12 +109,12 @@ exceptions with Syntax::Keyword::Try</a>.
 </div>
 
 For many apps Try::Tiny's performance problem is not a big deal. In terms of
-CPAN its a bigger deal because anytime you need great performance you need to
+CPAN it's a bigger deal because anytime you need great performance you need to
 worry if your dependencies (or their dependencies) are using Try::Tiny in some
 critical part of your code.
 
 Try::Tiny::Tiny is a module which improves the performance of Try::Tiny
-anywhere its loaded in your stack.  My benchmarks showed performance went from
+anywhere it is loaded in your stack.  My benchmarks showed performance went from
 20.2 times  slower than `eval` to 12.9 times slower than `eval` which is nearly
 an order of magnitude improvement.
 
@@ -134,7 +134,7 @@ dependencies that use Try::Tiny.
 Try::Catch is another attempt to improve on Try::Tiny.  My benchmarks showed
 this module is  8.4 times slower than `eval`.  This is also a new module
 (2017).  The syntax matches try/catch/finally in other languages better
-than Try::Tiny.  But its not as fast as Syntax::Keyword::Try and requires a
+than Try::Tiny.  But it's not as fast as Syntax::Keyword::Try and requires a
 semicolon at the end.
 
 #### TryCatch
@@ -148,7 +148,7 @@ semicolon at the end.
 
 TryCatch has first class try/catch semantics and type checking on the catch
 block.  My benchmarks showed this module has the same performance
-as Syntax::Keyword::Try.  It never was never broadly adopted because its
+as Syntax::Keyword::Try.  It never was broadly adopted because its
 dependencies include Devel::Declare
 (see the [warning](https://metacpan.org/pod/Devel::Declare#WARNING)) and Moose (lots of
 dependencies).  It also lacks a `finally` block.

--- a/page/cpan/files/index.markdown
+++ b/page/cpan/files/index.markdown
@@ -49,11 +49,11 @@ For most situations choosing one of these is probably the best way to go.
 </div>
 
 Path::Tiny is a small fast library with a fairly traditional object oriented
-interface for dealing with files and directories.  Its probably the most
+interface for dealing with files and directories.  It's probably the most
 popular high level module.
 
 Path::Tiny began life as a minimalist rewrite of the venerable Path::Class
-module with a improved user interface.  Over the years its grown in popularity
+module with a improved user interface.  Over the years it's grown in popularity
 and has become a mature, full featured library and one of the most common
 choices for dealing with files.  These days anyone interested in Path::Class is
 probably better served using Path::Tiny.
@@ -76,7 +76,7 @@ IO::Socket and MLDBM and LWP.  You can use it to create a web server, get files
 from ftp sites, or send email.
 
 The user interface is somewhat contraversial.  Depending on your point of view
-its powerful, concise, and convenient or makes for hard to read code at times.
+it's powerful, concise, and convenient or makes for hard to read code at times.
 
 Developers visiting Perl from another language are probably going to be more
 comfortable with Path::Tiny.

--- a/page/cpan/introduction/index.markdown
+++ b/page/cpan/introduction/index.markdown
@@ -1,7 +1,7 @@
 This goal of this chapter is to help developers quickly decide which modules to
 use.  
 
-MetaCPAN has thousands of modules. Its hard to know which module is the
+MetaCPAN has thousands of modules. It's hard to know which module is the
 best one.  For example there are at least 7 modules for parsing JSON.  New
 modules appear all the time which make the old best solution obsolete.  It can
 be hard to stay up to date.

--- a/page/cpan/web-frameworks/index.markdown
+++ b/page/cpan/web-frameworks/index.markdown
@@ -65,7 +65,7 @@ Rating: *Do not use*
 
 This is an old library which was created in 1995 and was extremely popular
 around 2000.  For a while it was part of the Perl core.  It was a good idea at
-the time.  Its not a good idea, 18+ years later, to use this to create new
+the time.  It's not a good idea, 18+ years later, to use this to create new
 applications.
 
 [CGI](https://metacpan.org/pod/distribution/CGI/lib/CGI.pod)

--- a/page/dependencies/cpanm/index.markdown
+++ b/page/dependencies/cpanm/index.markdown
@@ -3,7 +3,7 @@ The best way to install modules is with
 
 #### How to install cpanm
 
-Hopefully its already installed, but if not:
+Hopefully it's already installed, but if not:
 
     curl -L https://cpanmin.us | perl - --sudo App::cpanminus
 

--- a/page/essentials/die-eval/index.markdown
+++ b/page/essentials/die-eval/index.markdown
@@ -1,6 +1,6 @@
 
 The standard Perl syntax for handling exceptions (die/eval) is quirky and has
-some pitfalls that are easy to tumble into.  However its pretty common so 
+some pitfalls that are easy to tumble into.  However, it's pretty common so 
 you will need to understand it.
 
 <div class="tip">

--- a/page/essentials/fileio-builtins/index.markdown
+++ b/page/essentials/fileio-builtins/index.markdown
@@ -1,7 +1,7 @@
 # File IO with open() and close()
 
 Perl provides many built in functions for dealing with files.  They are commonly
-used so its worth learning how they work.  
+used so it's worth learning how they work.  
 
 If built in functions are your weapon of choice, you will also want to know
 which CPAN module to use when things get more complicated (File::Spec,

--- a/page/essentials/introduction/index.markdown
+++ b/page/essentials/introduction/index.markdown
@@ -13,7 +13,7 @@ MetaCPAN modules which improve on the basic functionality.
 
 Perl provides many builtin functions.  They are powerful, fast, concise, and
 are mostly backwards compatible.  Also you don't need to choose, install, and
-manage a module from MetaCPAN.  Use of built in functions is widespread so its
+manage a module from MetaCPAN.  Use of built in functions is widespread so it's
 almost always worth learning how they work.
 
 
@@ -36,7 +36,7 @@ looking at the docs.
 # Alternatives
 
 Again, depending on your preferences and your project, this might be fine.
-However, for many, its preferable and arguably easier and safer to use more
+However, for many, it's preferable and arguably easier and safer to use more
 modern or higher level mechanisms.  If that's you, consider some of the
 alternatives on MetaCPAN which solve these problems.  In this chapter I'll
 go over your options so you can choose the solution that's right for you.

--- a/page/essentials/try-catch/index.markdown
+++ b/page/essentials/try-catch/index.markdown
@@ -31,7 +31,7 @@ Syntax::Keyword::Try doesn't change how exceptions are thrown.
     use Syntax::Keyword::Try
 
     try {
-        die "its only a flesh wound";
+        die "it's only a flesh wound";
     }
     catch {
         warn "something bad happened: $@";
@@ -66,10 +66,10 @@ forgotten about try/catch:
 
 *2. A `try` block does not catch exceptions.*  The `catch` block catches exceptions.
 
-    try     { die "its just a flesh wound" }
+    try     { die "it's just a flesh wound" }
     finally { say "hello" }
     # no exception is caught
-    # prints "its just a flesh wound" to STDERR
+    # prints "it's just a flesh wound" to STDERR
     # process exits
 
 *3. A `return` statement will exit the containing function -- not the `try` block.*


### PR DESCRIPTION
Untested.

See:

https://www.grammar-monster.com/easily_confused/its_its.htm .

This was broken grammar / spelling / syntax / etc.